### PR TITLE
Get all pages of the results when listing repos

### DIFF
--- a/src/composer.js
+++ b/src/composer.js
@@ -11,6 +11,9 @@ module.exports.getDependenciesFromComposerLock = composerLockContents => {
     return undefined
   }
   const composerLockData = JSON.parse(composerLockContents)
+  if (!composerLockData.packages) {
+    return undefined
+  }
   return composerLockData.packages.map(dependency => ({
     name: dependency.name,
     version: dependency.version

--- a/src/github.js
+++ b/src/github.js
@@ -156,12 +156,25 @@ const listRepoContents = async (token, repo, path = '') => {
  * @returns {string[]} - List of repos. Example: ["silinternational/vulnerability-scanner"]
  */
 module.exports.listRepos = async (org, token) => {
-  const response = await request("GET /orgs/:org/repos", {
-    headers: {
-      authorization: "token " + token,
-    },
-    org: org,
-  })
-  const repos = response.data
-  return repos.map(repo => repo.full_name)
+  const allRepos = []
+  const pageSize = 100
+  
+  let page = 0
+  let thereAreMore = true
+  while (thereAreMore) {
+    page++
+    const response = await request("GET /orgs/:org/repos?per_page=:pageSize&page=:page", {
+      headers: {
+        authorization: "token " + token,
+      },
+      org: org,
+      page: page,
+      pageSize: pageSize
+    })
+    const repos = response.data
+    allRepos.push(...repos)
+    thereAreMore = (repos.length === pageSize)
+  } 
+  
+  return allRepos.map(repo => repo.full_name)
 }

--- a/src/github.js
+++ b/src/github.js
@@ -130,21 +130,26 @@ module.exports.getSecurityVulnerabilitiesForPackageUsingCache = mem(
 
 const listRepoContents = async (token, repo, path = '') => {
   const [repoOwner, repoName] = repo.split('/')
-  const response = await request(`GET /repos/:repoOwner/:repoName/contents/:path`, {
-    headers: {
-      authorization: "token " + token,
-    },
-    path: path,
-    repoOwner: repoOwner,
-    repoName: repoName,
-  })
-  const items = response.data
-  return items.map(item => ({
-    download_url: item.download_url,
-    name: item.name,
-    path: item.path,
-    type: item.type
-  }))
+  try {
+    const response = await request(`GET /repos/:repoOwner/:repoName/contents/:path`, {
+      headers: {
+        authorization: "token " + token,
+      },
+      path: path,
+      repoOwner: repoOwner,
+      repoName: repoName,
+    })
+    const items = response.data
+    return items.map(item => ({
+      download_url: item.download_url,
+      name: item.name,
+      path: item.path,
+      type: item.type
+    }))
+  } catch (e) {
+    console.error(`Error: ${e.message}`)
+    return []
+  }
 }
 
 /**


### PR DESCRIPTION
### Fixed
- Fix `listRepos()` to get all of the pages of the results, not just the first page
- Fix handling of essentially-empty composer.lock data
- Fix handling of empty GitHub repos
