### PR TITLE
Fix version/range comparison to handle comma-separated versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,10 +7,23 @@ const getSecurityVulnerabilitiesForPhpDependency = async (token, dependency) => 
     token,
     dependency.name
   )
-  return vulnerabilities.filter(vulnerability => semverSatisfies(
+  return vulnerabilities.filter(vulnerability => versionSatisfiesRange(
     dependency.version,
     vulnerability.vulnerableVersionRange
   ))
+}
+
+const versionSatisfiesRange = (version, gitHubVulnerableVersionRange) => {
+  /*
+   * NOTE: GitHub's `vulnerableVersionRange` uses a comma to separate the two
+   * version constraints of a range:
+   * https://docs.github.com/en/free-pro-team@latest/graphql/reference/objects#securityvulnerability
+   * 
+   * However, npm's semver doesn't know what to do with that comma. Removing it
+   * seems to result in a version range that npm's semver can understand.
+   */
+  const npmSemverRange = gitHubVulnerableVersionRange.replace(',', '')
+  return semverSatisfies(version, npmSemverRange)
 }
 
 /**


### PR DESCRIPTION
### Fixed
- Fix checking of version constraint to handle a comma in the range