### PR TITLE
Feature/exclude archived GitHub repos

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -162,7 +162,7 @@ const listRepoContents = async (token, repo, path = '') => {
  *
  * @param {string} token - A GitHub personal access token
  * @param {string} org - A GitHub organization's name
- * @returns {string[]} - List of repos. Example: ["silinternational/vulnerability-scanner"]
+ * @returns {Promise<string[]>} - List of repos. Example: ["silinternational/vulnerability-scanner"]
  */
 const listRepos = async (token, org) => {
   const allRepos = []

--- a/src/github.js
+++ b/src/github.js
@@ -181,7 +181,8 @@ const listRepos = async (token, org) => {
       pageSize: pageSize
     })
     const repos = response.data
-    allRepos.push(...repos)
+    const activeRepos = repos.filter(repo => !repo.archived)
+    allRepos.push(...activeRepos)
     thereAreMore = (repos.length === pageSize)
   } 
   


### PR DESCRIPTION
### Fixed
- Exclude archived GitHub repos, since the purpose is to list current vulnerabilities

---

Closes #20 