### PR TITLE
Feature/scan GitHub and bitbucket

### DIFF
--- a/cli/scan-bitbucket-workspace.js
+++ b/cli/scan-bitbucket-workspace.js
@@ -1,5 +1,6 @@
 const dotenv = require('dotenv')
 const { getSecurityVulnerabilitiesForBitbucketWorkspace } = require('../index')
+const { writeToCsv } = require('../src/csv')
 
 dotenv.config()
 
@@ -28,5 +29,5 @@ if (!username) {
     appPassword,
     githubToken,
     workspace
-  ).then(console.log)
+  ).then(writeToCsv)
 }

--- a/cli/scan-gh-bb.js
+++ b/cli/scan-gh-bb.js
@@ -1,0 +1,39 @@
+const assert = require('assert')
+const dotenv = require('dotenv')
+const { getSecurityVulnerabilitiesForMultiple } = require('../index')
+const { writeToCsv } = require('../src/csv')
+const { exitWithError } = require('../src/error')
+
+dotenv.config()
+
+const bbUsername = process.env.BITBUCKET_USERNAME
+const bbAppPassword = process.env.BITBUCKET_APP_PASSWORD
+const ghToken = process.env.GITHUB_TOKEN
+
+const ghOrg = process.argv[2]
+const bbWorkspace = process.argv[3]
+
+try {
+  assert(
+    process.argv.length > 2,
+    `Usage:\n  node cli/scan-gh-bb.js githuborganization bitbucketworkspace`
+  )
+  
+  assert(bbUsername, 'Please provide a BITBUCKET_USERNAME environment variable')
+  assert(bbAppPassword, 'Please provide a BITBUCKET_APP_PASSWORD environment variable')
+  assert(ghToken, 'Please provide a GITHUB_TOKEN environment variable to check for security vulnerabilities')
+
+  getSecurityVulnerabilitiesForMultiple({
+    bitbucket: {
+      username: bbUsername,
+      appPassword: bbAppPassword,
+      workspace: bbWorkspace,
+    },
+    github: {
+      organization: ghOrg,
+      token: ghToken,
+    },
+  }).then(writeToCsv).catch(exitWithError)
+} catch (e) {
+  exitWithError(e)
+}

--- a/cli/scan-github-org.js
+++ b/cli/scan-github-org.js
@@ -1,5 +1,6 @@
 const dotenv = require('dotenv')
 const { getSecurityVulnerabilitiesForGitHubOrg } = require('../index')
+const { writeToCsv } = require('../src/csv')
 
 dotenv.config()
 const githubToken = process.env.GITHUB_TOKEN
@@ -9,5 +10,5 @@ if (!githubOrg) {
   console.error('Please specify a GitHub organization')
   process.exitCode = 1;
 } else {
-  getSecurityVulnerabilitiesForGitHubOrg(githubToken, githubOrg).then(console.log)
+  getSecurityVulnerabilitiesForGitHubOrg(githubToken, githubOrg).then(writeToCsv)
 }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const assert = require('assert')
 const semverSatisfies = require('semver/functions/satisfies')
 const { convertToCsvString } = require('./src/csv')
 const bitbucket = require('./src/bitbucket')
@@ -20,9 +21,14 @@ const getSecurityVulnerabilitiesForMultiple = async config => {
   const bbConfig = config.bitbucket || {}
   const ghConfig = config.github || {}
   
+  assert(ghConfig.token, 'A GitHub token is required to check for vulnerabilities')
+  
   const allVulnerabilities = []
   
   if (bbConfig.workspace) {
+    assert(bbConfig.username, 'To scan a Bitbucket workspace, please provide a username')
+    assert(bbConfig.appPassword, 'To scan a Bitbucket workspace, please provide an app password')
+    
     const bbVulnerabilities = await getSecurityVulnerabilitiesForBitbucketWorkspace(
       bbConfig.username,
       bbConfig.appPassword,

--- a/index.js
+++ b/index.js
@@ -4,6 +4,46 @@ const bitbucket = require('./src/bitbucket')
 const github = require('./src/github')
 
 /**
+ * Get the security vulnerabilities for the specified version control systems.
+ *
+ * If a Bitbucket workspace is specified, it will be scanner.
+ *
+ * If a GitHub organization is specified, it will be scanner.
+ *
+ * @param {{
+    bitbucket: { username: string?, appPassword: string?, workspace: string? },
+    github: { token: string, organization: string? }
+    }} config
+ * @returns {Promise<[]>}
+ */
+const getSecurityVulnerabilitiesForMultiple = async config => {
+  const bbConfig = config.bitbucket || {}
+  const ghConfig = config.github || {}
+  
+  const allVulnerabilities = []
+  
+  if (bbConfig.workspace) {
+    const bbVulnerabilities = await getSecurityVulnerabilitiesForBitbucketWorkspace(
+      bbConfig.username,
+      bbConfig.appPassword,
+      ghConfig.token,
+      bbConfig.workspace
+    )
+    allVulnerabilities.push(...bbVulnerabilities)
+  }
+  
+  if (ghConfig.organization) {
+    const ghVulnerabilities = await getSecurityVulnerabilitiesForGitHubOrg(
+      ghConfig.token,
+      ghConfig.organization
+    )
+    allVulnerabilities.push(...ghVulnerabilities)
+  }
+  
+  return allVulnerabilities
+}
+
+/**
  * Get the security vulnerabilities for the specified Bitbucket repo. It will
  * return an array of vulnerabilities, or `undefined` if the Bitbucket repo's
  * dependencies could not be determined.
@@ -237,5 +277,6 @@ module.exports = {
   getSecurityVulnerabilitiesForBitbucketRepo,
   getSecurityVulnerabilitiesForBitbucketWorkspace,
   getSecurityVulnerabilitiesForGitHubOrg,
-  getSecurityVulnerabilitiesForGitHubRepo
+  getSecurityVulnerabilitiesForGitHubRepo,
+  getSecurityVulnerabilitiesForMultiple,
 }

--- a/index.js
+++ b/index.js
@@ -23,6 +23,11 @@ const getSecurityVulnerabilitiesForMultiple = async config => {
   
   assert(ghConfig.token, 'A GitHub token is required to check for vulnerabilities')
   
+  assert(
+    bbConfig.workspace || ghConfig.organization,
+    'You must specify a GitHub organization, a Bitbucket workspace, or both'
+  )
+  
   const allVulnerabilities = []
   
   if (bbConfig.workspace) {

--- a/src/error.js
+++ b/src/error.js
@@ -1,0 +1,9 @@
+
+const exitWithError = error => {
+  console.error(error.message)
+  process.exitCode = 1
+}
+
+module.exports = {
+  exitWithError
+}


### PR DESCRIPTION
### Added
- Enable scanning both GitHub and Bitbucket in a single run

### Fixed
- When using the CLI to scan an entire org. or workspace, write the results to a local CSV