### PR TITLE
Don't look in "vendor/" when searching for composer.lock file

### DIFF
--- a/src/bitbucket.js
+++ b/src/bitbucket.js
@@ -37,7 +37,9 @@ const findFile = async (username, appPassword, repo, fileName) => {
       appPassword,
       `repositories/${uriEncWorkspace}/${uriEncRepoSlug}/src`,
       ['values.attributes,values.links.self.href,values.path'],
-      '&max_depth=50&q=' + encodeURIComponent(`path ~ "${fileName}" and type = "commit_file"`)
+      '&max_depth=50&q=' + encodeURIComponent(
+        `path ~ "${fileName}" and path !~ "vendor/" and type = "commit_file"`
+      )
     )
     
     const files = items.filter(isNotASymbolicLink)


### PR DESCRIPTION
### Fixed
- Don't look in "vendor/" when searching for composer.lock file on Bitbucket