### PR TITLE
Reduce the number of API calls to GitHub by caching `listRepoContents()`

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -18,7 +18,7 @@ const findFile = async (token, repo, fileName) => {
 }
 
 const findFiles = async (token, repo, fileName, initialPath = '') => {
-  const items = await listRepoContents(token, repo, initialPath)
+  const items = await listRepoContentsUsingCache(token, repo, initialPath)
   
   const matchingFiles = []
   const files = items.filter(item => item.type === 'file')
@@ -216,6 +216,10 @@ const listRepoContents = async (token, repo, path = '') => {
     return []
   }
 }
+const listRepoContentsUsingCache = mem(
+  listRepoContents,
+  { cacheKey: JSON.stringify }
+)
 
 /**
  * List the GitHub repos for the specified organization that are visible when


### PR DESCRIPTION
Here's a much shorter PR 🙂 

---

### Fixed
- Cache calls to list contents of GitHub repo, to avoid duplicate calls (and rate limits)