### PR TITLE
Reduce chances of hitting Bitbucket API rate limit

### DIFF
--- a/src/bitbucket.js
+++ b/src/bitbucket.js
@@ -113,7 +113,7 @@ const listFilesInRepo = async (username, appPassword, repo) => {
       appPassword,
       `repositories/${uriEncWorkspace}/${uriEncRepoSlug}/src`,
       ['values.attributes,values.links.self.href,values.path'],
-      '&max_depth=50&q=' + encodeURIComponent(
+      '&max_depth=5&q=' + encodeURIComponent(
         `path !~ "vendor/" and type = "commit_file"`
       )
     )

--- a/src/bitbucket.js
+++ b/src/bitbucket.js
@@ -183,7 +183,7 @@ const getAllPagesOfResults = async (username, appPassword, uriEncodedResourcePat
   
   const allResults = []
   let page = 0
-  const maxPages = 100
+  const maxPages = 20
   while (url && (page < maxPages)) {
     page++
     const response = await request(`GET ${url}`, {

--- a/src/bitbucket.js
+++ b/src/bitbucket.js
@@ -192,8 +192,8 @@ const getAllPagesOfResults = async (username, appPassword, uriEncodedResourcePat
       },
     })
     url = response.data.next
-    const repos = response.data.values
-    allResults.push(...repos)
+    const results = response.data.values
+    allResults.push(...results)
   }
   
   if (page >= maxPages) {

--- a/src/bitbucket.js
+++ b/src/bitbucket.js
@@ -94,6 +94,15 @@ const findFile = async (username, appPassword, repo, fileName) => {
 }
 
 const findFiles = async (username, appPassword, repo, fileName) => {
+  const files = await listFilesInRepo(username, appPassword, repo)
+  return files.filter(file => hasFileName(file.path, fileName))
+}
+
+const hasFileName = (filePath, fileName) => {
+  return (filePath === fileName) || filePath.endsWith(`/${fileName}`)
+}
+
+const listFilesInRepo = async (username, appPassword, repo) => {
   const [workspace, repoSlug] = repo.split('/')
   try {
     const uriEncWorkspace = encodeURIComponent(workspace)
@@ -104,7 +113,7 @@ const findFiles = async (username, appPassword, repo, fileName) => {
       `repositories/${uriEncWorkspace}/${uriEncRepoSlug}/src`,
       ['values.attributes,values.links.self.href,values.path'],
       '&max_depth=50&q=' + encodeURIComponent(
-        `path ~ "${fileName}" and path !~ "vendor/" and type = "commit_file"`
+        `path !~ "vendor/" and type = "commit_file"`
       )
     )
     

--- a/src/bitbucket.js
+++ b/src/bitbucket.js
@@ -1,3 +1,4 @@
+const assert = require('assert')
 const composer = require('./composer')
 const docker = require('./docker')
 const mem = require('mem')
@@ -108,7 +109,12 @@ const findFile = async (username, appPassword, repo, fileName) => {
 }
 
 const findFiles = async (username, appPassword, repo, fileName) => {
-  const files = await listFilesInRepoUsingCache(username, appPassword, repo)
+  const entries = fileNamesOfInterest.join(', ')
+  assert(
+    fileNamesOfInterest.some(entry => entry === fileName),
+    `To find files named ${fileName}, add it to our fileNamesOfInterest list: ${entries}.`
+  )
+  const files = await listFilesOfInterestInRepoUsingCache(username, appPassword, repo)
   return files.filter(file => hasFileName(file.path, fileName))
 }
 

--- a/src/bitbucket.js
+++ b/src/bitbucket.js
@@ -1,5 +1,6 @@
 const composer = require('./composer')
 const docker = require('./docker')
+const mem = require('mem')
 const npm = require('./npm')
 const { request } = require("@octokit/request")
 
@@ -94,7 +95,7 @@ const findFile = async (username, appPassword, repo, fileName) => {
 }
 
 const findFiles = async (username, appPassword, repo, fileName) => {
-  const files = await listFilesInRepo(username, appPassword, repo)
+  const files = await listFilesInRepoUsingCache(username, appPassword, repo)
   return files.filter(file => hasFileName(file.path, fileName))
 }
 
@@ -132,6 +133,10 @@ const listFilesInRepo = async (username, appPassword, repo) => {
   }
   return []
 }
+const listFilesInRepoUsingCache = mem(
+  listFilesInRepo,
+  { cacheKey: arguments => arguments[2] }
+)
 
 /**
  * Useful for filtering lists of entries in a repo to remove symlinks. See

--- a/src/bitbucket.js
+++ b/src/bitbucket.js
@@ -140,7 +140,7 @@ const listFilesOfInterestInRepo = async (username, appPassword, repo) => {
       appPassword,
       `repositories/${uriEncWorkspace}/${uriEncRepoSlug}/src`,
       ['values.attributes,values.links.self.href,values.path'],
-      '&max_depth=5&q=' + encodeURIComponent(
+      '&max_depth=10&q=' + encodeURIComponent(
         `(${fileNamesCondition}) and path !~ "vendor/" and type = "commit_file"`
       )
     )

--- a/src/bitbucket.js
+++ b/src/bitbucket.js
@@ -18,6 +18,14 @@ const fileNamesOfInterest = [
   'package-lock.json'
 ]
 
+const assertFileNameIsInListWeSearchFor = fileName => {
+  const entries = fileNamesOfInterest.join(', ')
+  assert(
+    fileNamesOfInterest.some(entry => entry === fileName),
+    `To find files named ${fileName}, add it to our fileNamesOfInterest list: ${entries}.`
+  )
+}
+
 /**
  * Get the base images used in each of the specified Bitbucket repo's
  * Dockerfiles.
@@ -109,11 +117,7 @@ const findFile = async (username, appPassword, repo, fileName) => {
 }
 
 const findFiles = async (username, appPassword, repo, fileName) => {
-  const entries = fileNamesOfInterest.join(', ')
-  assert(
-    fileNamesOfInterest.some(entry => entry === fileName),
-    `To find files named ${fileName}, add it to our fileNamesOfInterest list: ${entries}.`
-  )
+  assertFileNameIsInListWeSearchFor(fileName)
   const files = await listFilesOfInterestInRepoUsingCache(username, appPassword, repo)
   return files.filter(file => hasFileName(file.path, fileName))
 }

--- a/src/bitbucket.js
+++ b/src/bitbucket.js
@@ -5,6 +5,19 @@ const npm = require('./npm')
 const { request } = require("@octokit/request")
 
 /**
+ * Names of files in a Bitbucket repo that we may want to know about. We list
+ * them explicitly so that we can make fewer API calls to Bitbucket when looking
+ * for files (i.e. fewer pages of results to separately request from Bitbucket).
+ *
+ * @type {string[]}
+ */
+const fileNamesOfInterest = [
+  'Dockerfile',
+  'composer.lock',
+  'package-lock.json'
+]
+
+/**
  * Get the base images used in each of the specified Bitbucket repo's
  * Dockerfiles.
  *
@@ -103,7 +116,11 @@ const hasFileName = (filePath, fileName) => {
   return (filePath === fileName) || filePath.endsWith(`/${fileName}`)
 }
 
-const listFilesInRepo = async (username, appPassword, repo) => {
+const listFilesOfInterestInRepo = async (username, appPassword, repo) => {
+  const pathIsLikeFileNameConditions = fileNamesOfInterest.map(
+    fileName => `path ~ "${fileName}"`
+  )
+  const fileNamesCondition = pathIsLikeFileNameConditions.join(' OR ')
   const [workspace, repoSlug] = repo.split('/')
   try {
     const uriEncWorkspace = encodeURIComponent(workspace)
@@ -114,7 +131,7 @@ const listFilesInRepo = async (username, appPassword, repo) => {
       `repositories/${uriEncWorkspace}/${uriEncRepoSlug}/src`,
       ['values.attributes,values.links.self.href,values.path'],
       '&max_depth=5&q=' + encodeURIComponent(
-        `path !~ "vendor/" and type = "commit_file"`
+        `(${fileNamesCondition}) and path !~ "vendor/" and type = "commit_file"`
       )
     )
     
@@ -133,8 +150,8 @@ const listFilesInRepo = async (username, appPassword, repo) => {
   }
   return []
 }
-const listFilesInRepoUsingCache = mem(
-  listFilesInRepo,
+const listFilesOfInterestInRepoUsingCache = mem(
+  listFilesOfInterestInRepo,
   { cacheKey: arguments => arguments[2] }
 )
 

--- a/src/bitbucket.js
+++ b/src/bitbucket.js
@@ -114,7 +114,12 @@ const findFiles = async (username, appPassword, repo, fileName) => {
       path: file.path
     }))
   } catch (e) {
-    console.error(`Error: ${e.message}`)
+    if (e.message.includes('This repository is empty')) {
+      console.warn(`Warning: ${e.message}`)
+    } else {
+      console.error(`Error (${e.status}): ${e.message}`)
+      throw e
+    }
   }
   return []
 }

--- a/src/github.js
+++ b/src/github.js
@@ -212,8 +212,12 @@ const listRepoContents = async (token, repo, path = '') => {
       type: item.type
     }))
   } catch (e) {
-    console.error(`Error: ${e.message}`)
-    return []
+    if (e.message.includes('This repository is empty')) {
+      console.warn(`Warning: ${e.message}`)
+      return []
+    }
+    console.error(`Error (${e.status}): ${e.message}`)
+    throw e
   }
 }
 const listRepoContentsUsingCache = mem(


### PR DESCRIPTION
### Fixed
- Reduce folder-depth (when searching Bitbucket repo for files) down from 50 to more reasonable 10
- Just search for specific file names when finding files in Bitbucket
- Cache results of listing files in a Bitbucket repo
- Stop after 20 pages (of 100 items) when getting Bitbucket API results, to reduce wasting rate-limited API calls
- Exit with an error if an API call returns an error (except errors about empty repos)
