### PR TITLE
Exclude archived Bitbucket repos

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -6,3 +6,6 @@ BITBUCKET_APP_PASSWORD=
 
 # Your GitHub Personal Access Token
 GITHUB_TOKEN=
+
+# (Optional, only needed for tests:) Bitbucket workspace to use in tests
+BITBUCKET_WORKSPACE_FOR_TESTS=

--- a/.env.dist
+++ b/.env.dist
@@ -7,5 +7,5 @@ BITBUCKET_APP_PASSWORD=
 # Your GitHub Personal Access Token
 GITHUB_TOKEN=
 
-# (Optional, only needed for tests:) Bitbucket workspace to use in tests
+# (Optional, only needed for integration tests:) Bitbucket workspace to use in tests
 BITBUCKET_WORKSPACE_FOR_TESTS=

--- a/features/bitbucket/listRepos.feature
+++ b/features/bitbucket/listRepos.feature
@@ -1,5 +1,6 @@
 Feature: Listing repos in a Bitbucket workspace
   
+  @integration
   Scenario: List repos
     When I get the list of repos
     Then the result will be an array of strings

--- a/features/bitbucket/listRepos.feature
+++ b/features/bitbucket/listRepos.feature
@@ -1,0 +1,6 @@
+Feature: Listing repos in a Bitbucket workspace
+  
+  Scenario: List repos
+    When I get the list of repos
+    Then the result will be an array of strings
+      And none of those repo names will end with "_archived"

--- a/features/bitbucket/listRepos.js
+++ b/features/bitbucket/listRepos.js
@@ -1,0 +1,46 @@
+const { Given, When, Then } = require('@cucumber/cucumber')
+const assert = require('assert')
+const dotenv = require('dotenv')
+const bitbucket = require('../../src/bitbucket')
+
+dotenv.config()
+
+const username = process.env.BITBUCKET_USERNAME
+const appPassword = process.env.BITBUCKET_APP_PASSWORD
+const workspace = process.env.BITBUCKET_WORKSPACE_FOR_TESTS
+
+let repoNames = []
+
+When('I get the list of repos', async function () {
+  repoNames = await bitbucket.listRepos(
+    username,
+    appPassword,
+    workspace
+  )
+})
+
+Then('the result will be an array of strings', function () {
+  if (!Array.isArray(repoNames)) {
+    assert.fail('The result was this:' + JSON.stringify(repoNames))
+  }
+  
+  if (repoNames.length < 1) {
+    assert.fail('The array must have at least one entry in it (for this test)')
+  }
+  
+  repoNames.forEach(repoName => {
+    assert.strictEqual(
+      typeof repoName,
+      'string',
+      'Expected this to be a string: ' + JSON.stringify(repoName)
+    )
+  })
+})
+
+Then('none of those repo names will end with {string}', function (suffix) {
+  repoNames.forEach(repoName => {
+    if (repoName.endsWith(suffix)) {
+      assert.fail(JSON.stringify(repoName) + ' ends with ' + JSON.stringify(suffix))
+    }
+  })
+})

--- a/features/bitbucket/listRepos.js
+++ b/features/bitbucket/listRepos.js
@@ -12,6 +12,9 @@ const workspace = process.env.BITBUCKET_WORKSPACE_FOR_TESTS
 let repoNames = []
 
 When('I get the list of repos', async function () {
+  if (!workspace) {
+    assert.fail('Please provide a BITBUCKET_WORKSPACE_FOR_TESTS environment variable')
+  }
   repoNames = await bitbucket.listRepos(
     username,
     appPassword,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "semver": "^7.3.2"
   },
   "scripts": {
-    "test": "./node_modules/@cucumber/cucumber/bin/cucumber-js"
+    "test": "./node_modules/@cucumber/cucumber/bin/cucumber-js",
+    "test-ci": "./node_modules/@cucumber/cucumber/bin/cucumber-js --tags \"not @integration\""
   },
   "repository": {
     "type": "git",

--- a/src/bitbucket.js
+++ b/src/bitbucket.js
@@ -199,7 +199,8 @@ const listRepos = async (username, appPassword, workspace) => {
     `repositories/${encodeURIComponent(workspace)}`,
     ['values.full_name']
   )
-  return repos.map(repo => repo.full_name)
+  const activeRepos = repos.filter(isActiveRepo)
+  return activeRepos.map(repo => repo.full_name)
 }
 
 const getAllPagesOfResults = async (username, appPassword, uriEncodedResourcePath, fields, uriEncExtraQuery = '') => {
@@ -231,6 +232,14 @@ const getAllPagesOfResults = async (username, appPassword, uriEncodedResourcePat
   
   return allResults
 }
+
+/**
+ * Whether the given repo is active (i.e. not archived).
+ *
+ * @param {{full_name: string}} repo
+ * @return {boolean}
+ */
+const isActiveRepo = repo => !repo.full_name.endsWith('_archived')
 
 module.exports = {
   getDockerBaseImagesOfRepo,


### PR DESCRIPTION
### Fixed
- Update `bitbucket.listRepos()` to exclude archived repos (indicated by an "_archived" suffix on the repo name)

### Added
- Add a way to run only the non-integration tests

---

Closes #57 
