### PR TITLE
Fix helper script to skip unknown docker image, not say "NONE" for them

### DIFF
--- a/get-docker-lang-versions.sh
+++ b/get-docker-lang-versions.sh
@@ -4,6 +4,12 @@ printf 'Docker image,PHP version,NodeJS version,Python version\n' > docker-lang-
 
 while IFS= read -r dockerImage; do
   docker pull "$dockerImage"
+  if [ $? -eq 0 ]; then
+    echo "Pulled $dockerImage"
+  else
+    echo "Unknown docker image: $dockerImage"
+    continue
+  fi
   
   docker run --rm --entrypoint php "$dockerImage" -v &>/dev/null
   if [ $? -eq 0 ]; then


### PR DESCRIPTION
### Fixed
- Fix helper script to skip unknown docker image, not say "NONE" for them

---

Previously, it was giving false-negatives, saying that a docker image that we failed to pull simply didn't use any of the programming languages we were checking for.