### PR TITLE
Include docker image name in NodeJS and PHP End-Of-Life version warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -794,7 +794,7 @@ const getPhpVersionEolVulnerability = async (dockerImage, versionsCsvUrl) => {
       vulnerableVersionRange: null
     }
   } else if (isPhpVersionEOL === true) {
-    const eolPhpVersionWarning = `PHP ${phpVersion} has reached End-Of-Life`
+    const eolPhpVersionWarning = `${dockerImage} uses PHP ${phpVersion}, which has reached End-Of-Life`
     console.log(eolPhpVersionWarning)
     return {
       detailsUrl: 'https://php.net/eol',

--- a/index.js
+++ b/index.js
@@ -503,7 +503,7 @@ const getNodeJsVersionEolVulnerability = async (dockerImage, versionsCsvUrl) => 
       vulnerableVersionRange: null
     }
   } else if (isNodeJsVersionEOL === true) {
-    const eolNodeJsVersionWarning = `NodeJS ${nodeJsVersion} has reached End-Of-Life`
+    const eolNodeJsVersionWarning = `${dockerImage} uses NodeJS ${nodeJsVersion}, which has reached End-Of-Life`
     console.log(eolNodeJsVersionWarning)
     return {
       detailsUrl: 'https://nodejs.org/en/about/releases/',


### PR DESCRIPTION
### Added
- Include the Docker image name in NodeJS End-Of-Life warnings
- Include the Docker image name in PHP End-Of-Life warnings

---

Fixes #71 (at least the intent of the one use case provided... if more needs arise, more issues can be opened)