### PR TITLE
Fix cross-architecture bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .env
 .idea
 node_modules
+docker-lang-versions.txt
+docker-images-unknown-versions.txt

--- a/get-docker-lang-versions.sh
+++ b/get-docker-lang-versions.sh
@@ -11,21 +11,21 @@ while IFS= read -r dockerImage; do
     continue
   fi
 
-  docker run --rm --platform=linux/amd64 --entrypoint php "$dockerImage" -v &>/dev/null
+  docker run --rm --platform=linux/amd64 --entrypoint php "$dockerImage" -v 1>/dev/null
   if [ $? -eq 0 ]; then
     phpVersion=$(docker run --rm --platform=linux/amd64 --entrypoint php "$dockerImage" -r "echo PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;")
   else
     phpVersion="NONE"
   fi
 
-  docker run --rm --platform=linux/amd64 --entrypoint node "$dockerImage" -v &>/dev/null
+  docker run --rm --platform=linux/amd64 --entrypoint node "$dockerImage" -v 1>/dev/null
   if [ $? -eq 0 ]; then
     nodeVersion=$(docker run --rm --platform=linux/amd64 --entrypoint node "$dockerImage" -e "console.log(process.version.match(/^(v?\d+)\./)[1])")
   else
     nodeVersion="NONE"
   fi
 
-  docker run --rm --platform=linux/amd64 --entrypoint python "$dockerImage" --version &>/dev/null
+  docker run --rm --platform=linux/amd64 --entrypoint python "$dockerImage" --version 1>/dev/null
   if [ $? -eq 0 ]; then
     pythonVersion=$(docker run --rm --platform=linux/amd64 --entrypoint python "$dockerImage" -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))')
   else

--- a/get-docker-lang-versions.sh
+++ b/get-docker-lang-versions.sh
@@ -11,12 +11,15 @@ while IFS= read -r dockerImage; do
     continue
   fi
 
+  echo "Checking versions in $dockerImage:"
+
   docker run --rm --platform=linux/amd64 --entrypoint php "$dockerImage" -v 1>/dev/null
   if [ $? -eq 0 ]; then
     phpVersion=$(docker run --rm --platform=linux/amd64 --entrypoint php "$dockerImage" -r "echo PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;")
   else
     phpVersion="NONE"
   fi
+  echo " - PHP version: $phpVersion"
 
   docker run --rm --platform=linux/amd64 --entrypoint node "$dockerImage" -v 1>/dev/null
   if [ $? -eq 0 ]; then
@@ -24,6 +27,7 @@ while IFS= read -r dockerImage; do
   else
     nodeVersion="NONE"
   fi
+  echo " - NodeJS version: $nodeVersion"
 
   docker run --rm --platform=linux/amd64 --entrypoint python "$dockerImage" --version 1>/dev/null
   if [ $? -eq 0 ]; then
@@ -31,6 +35,7 @@ while IFS= read -r dockerImage; do
   else
     pythonVersion="NONE"
   fi
+  echo " - Python version: $pythonVersion"
 
   printf '%s,%s,%s,%s\n' "$dockerImage" "$phpVersion" "$nodeVersion" "$pythonVersion" >> docker-lang-versions.txt
 done

--- a/get-docker-lang-versions.sh
+++ b/get-docker-lang-versions.sh
@@ -10,27 +10,27 @@ while IFS= read -r dockerImage; do
     echo "Unknown docker image: $dockerImage"
     continue
   fi
-  
-  docker run --rm --entrypoint php "$dockerImage" -v &>/dev/null
+
+  docker run --rm --platform=linux/amd64 --entrypoint php "$dockerImage" -v &>/dev/null
   if [ $? -eq 0 ]; then
-    phpVersion=$(docker run --rm --entrypoint php "$dockerImage" -r "echo PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;")
+    phpVersion=$(docker run --rm --platform=linux/amd64 --entrypoint php "$dockerImage" -r "echo PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;")
   else
     phpVersion="NONE"
   fi
-  
-  docker run --rm --entrypoint node "$dockerImage" -v &>/dev/null
+
+  docker run --rm --platform=linux/amd64 --entrypoint node "$dockerImage" -v &>/dev/null
   if [ $? -eq 0 ]; then
-    nodeVersion=$(docker run --rm --entrypoint node "$dockerImage" -e "console.log(process.version.match(/^(v?\d+)\./)[1])")
+    nodeVersion=$(docker run --rm --platform=linux/amd64 --entrypoint node "$dockerImage" -e "console.log(process.version.match(/^(v?\d+)\./)[1])")
   else
     nodeVersion="NONE"
   fi
-  
-  docker run --rm --entrypoint python "$dockerImage" --version &>/dev/null
+
+  docker run --rm --platform=linux/amd64 --entrypoint python "$dockerImage" --version &>/dev/null
   if [ $? -eq 0 ]; then
-    pythonVersion=$(docker run --rm --entrypoint python "$dockerImage" -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))')
+    pythonVersion=$(docker run --rm --platform=linux/amd64 --entrypoint python "$dockerImage" -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))')
   else
     pythonVersion="NONE"
   fi
-  
+
   printf '%s,%s,%s,%s\n' "$dockerImage" "$phpVersion" "$nodeVersion" "$pythonVersion" >> docker-lang-versions.txt
 done


### PR DESCRIPTION
### Fixed
- Specifically run the linux/amd64 version of the given images when checking docker image versions locally
- Ignore the example files used for checking multiple docker images
- Stop hiding stderr when checking docker image versions locally, in case there was a meaningful/unexpected error

### Added
- Show results as we go when checking docker image versions locally

---

I realized this was a problem when I was getting a PHP version of "NONE" for our PHP docker images. It turns out that error messages like this we're being hidden:
> docker: Error response from daemon: image with reference silintl/ssp-base:7.2.0 was found but does not match the specified platform: wanted linux/arm64, actual: linux/amd64.

This is because I was running this in an Apple computer with an M1 chip, but we publish linux/amd64 versions of applications, not (generally) linux/arm64 versions.