### PR TITLE
Cache calls for file contents

### DIFF
--- a/src/bitbucket.js
+++ b/src/bitbucket.js
@@ -89,7 +89,7 @@ const getPhpDependenciesOfRepo = async (username, appPassword, repo) => {
 const getContentsOfFileByName = async (username, appPassword, repo, fileName) => {
   const file = await findFile(username, appPassword, repo, fileName)
   if (file !== undefined) {
-    return getContentsOfFileByDownloadUrl(username, appPassword, file.download_url)
+    return getContentsOfFileByDownloadUrlUsingCache(username, appPassword, file.download_url)
   }
   return undefined
 }
@@ -97,7 +97,7 @@ const getContentsOfFileByName = async (username, appPassword, repo, fileName) =>
 const getContentsOfFilesByName = async (username, appPassword, repo, fileName) => {
   const files = await findFiles(username, appPassword, repo, fileName)
   return Promise.all(
-    files.map(file => getContentsOfFileByDownloadUrl(
+    files.map(file => getContentsOfFileByDownloadUrlUsingCache(
       username,
       appPassword,
       file.download_url
@@ -183,6 +183,10 @@ const getContentsOfFileByDownloadUrl = async (username, appPassword, downloadUrl
   })
   return response.data
 }
+const getContentsOfFileByDownloadUrlUsingCache = mem(
+    getContentsOfFileByDownloadUrl,
+    { cacheKey: arguments => arguments[2] }
+)
 
 /**
  * List the Bitbucket repos for the specified workspace that are visible when

--- a/src/bitbucket.js
+++ b/src/bitbucket.js
@@ -175,6 +175,7 @@ const listFilesOfInterestInRepoUsingCache = mem(
 const isNotASymbolicLink = item => !item.attributes.some(attribute => attribute === 'link')
 
 const getContentsOfFileByDownloadUrl = async (username, appPassword, downloadUrl) => {
+  console.debug(`Getting contents of ${downloadUrl}`)
   const response = await request(`GET ${downloadUrl}`, {
     headers: {
       authorization: "Basic " + Buffer.from(`${username}:${appPassword}`).toString('base64'),

--- a/src/github.js
+++ b/src/github.js
@@ -56,6 +56,7 @@ const getContentsOfFilesByName = async (token, repo, fileName) => {
 }
 
 const getContentsOfFileByDownloadUrl = async (token, downloadUrl) => {
+  console.debug(`Getting contents of ${downloadUrl}`)
   const response = await request(`GET ${downloadUrl}`, {
     headers: {
       authorization: "token " + token,

--- a/src/github.js
+++ b/src/github.js
@@ -40,7 +40,7 @@ const findFiles = async (token, repo, fileName, initialPath = '') => {
 const getContentsOfFileByName = async (token, repo, fileName) => {
   const file = await findFile(token, repo, fileName)
   if (file !== undefined) {
-    return getContentsOfFileByDownloadUrl(token, file.download_url)
+    return getContentsOfFileByDownloadUrlUsingCache(token, file.download_url)
   }
   return undefined
 }
@@ -48,7 +48,7 @@ const getContentsOfFileByName = async (token, repo, fileName) => {
 const getContentsOfFilesByName = async (token, repo, fileName) => {
   const files = await findFiles(token, repo, fileName)
   return Promise.all(
-    files.map(file => getContentsOfFileByDownloadUrl(
+    files.map(file => getContentsOfFileByDownloadUrlUsingCache(
       token,
       file.download_url
     ))
@@ -64,6 +64,10 @@ const getContentsOfFileByDownloadUrl = async (token, downloadUrl) => {
   })
   return response.data
 }
+const getContentsOfFileByDownloadUrlUsingCache = mem(
+    getContentsOfFileByDownloadUrl,
+    { cacheKey: arguments => arguments[1] }
+)
 
 /**
  * Get the base images used in each of the specified GitHub repo's Dockerfiles.


### PR DESCRIPTION
### Fixed
- Stop re-requesting a file's contents if we already have it (aka use a cache)
- Show (in a debug log line) what file we're retrieving the contents of