### PR TITLE
Exclude aliases from the list of Docker images that a Dockerfile uses

### DIFF
--- a/features/docker/getBaseImagesFrom.feature
+++ b/features/docker/getBaseImagesFrom.feature
@@ -26,3 +26,17 @@ Feature: Extracting Docker base image details from a Dockerfile
       owner/builder
       owner/base
       """
+
+  Scenario: Multistage Dockerfile that also builds from aliases
+    Given a Dockerfile with the following contents:
+      """
+      FROM owner/builder AS base
+      COPY something
+      FROM base
+      RUN something-else
+      """
+    When I get the base images from that Dockerfile
+    Then the result will be the following:
+      """
+      owner/builder
+      """

--- a/src/docker.js
+++ b/src/docker.js
@@ -3,6 +3,11 @@ const { readCsvString } = require('./csv')
 const mem = require('mem')
 const { request } = require('@octokit/request')
 
+const getAliasFromFromLine = fromLine => {
+  const regexMatchResult = fromLine.match(/FROM [^ ]+ AS ([^ ]+)/i)
+  return Array.isArray(regexMatchResult) ? regexMatchResult[1] : null
+}
+
 /**
  * Get the base image(s) specified in the FROM line(s) of the provided
  * Dockerfile contents.
@@ -16,7 +21,8 @@ const getBaseImagesFrom = dockerfileContents => {
   }
   
   const fromLines = getFromLines(dockerfileContents)
-  const dockerImages = fromLines.map(getDockerImageFromFromLine)
+  const fromLinesExcludingAliases = removeFromAliasLines(fromLines)
+  const dockerImages = fromLinesExcludingAliases.map(getDockerImageFromFromLine)
   return dockerImages.filter(dockerImage => dockerImage !== null)
 }
 
@@ -87,6 +93,23 @@ const getVersionsCsvUsingCache = mem(
   getVersionsCsv,
   { cacheKey: JSON.stringify }
 )
+
+const isFromAlias = (fromLine, alias) => {
+  const dockerImage = getDockerImageFromFromLine(fromLine)
+  return dockerImage === alias
+}
+
+const isFromAnAlias = (fromLine, aliases) => aliases.some(alias => isFromAlias(fromLine, alias))
+
+const isNotFromAnAlias = (fromLine, aliases) => !isFromAnAlias(fromLine, aliases)
+
+const isNotNull = value => value !== null
+
+const removeFromAliasLines = fromLines => {
+  const aliases = fromLines.map(getAliasFromFromLine)
+  const nonEmptyAliases = aliases.filter(isNotNull)
+  return fromLines.filter((fromLine) => isNotFromAnAlias(fromLine, nonEmptyAliases))
+}
 
 module.exports = {
   getBaseImagesFrom,


### PR DESCRIPTION
### Fixed
- Exclude aliases from the list of Docker images that a Dockerfile uses