### PR TITLE
Add scan.js

### DIFF
--- a/cli/scan.js
+++ b/cli/scan.js
@@ -1,0 +1,65 @@
+const assert = require('assert')
+const dotenv = require('dotenv')
+const { getSecurityVulnerabilitiesForMultiple } = require('../index')
+const { writeToCsv } = require('../src/csv')
+const { exitWithError } = require('../src/error')
+
+dotenv.config()
+
+const bbUsername = process.env.BITBUCKET_USERNAME
+const bbAppPassword = process.env.BITBUCKET_APP_PASSWORD
+const token = process.env.GITHUB_TOKEN
+
+const args = process.argv.splice(2)
+
+try {
+  assert(
+    process.argv.length > 2,
+    `Usage:\n  node cli/scan.js --github="org" --bitbucket="workspace" --csv="versions.url"\n\n` +
+    `  -g, --github       The Github organization to scan\n` +
+    `  -b, --bitbucket    The Bitbucket workspace to scan\n` +
+    `  -c, --csv          The url to the versions csv file\n`
+  )
+
+  assert(token, 'Please provide a GITHUB_TOKEN environment variable to check for security vulnerabilities')
+
+  const bitbucket = { }
+  const github = { token }
+  let versionsCsvUrl = ''
+
+  for (const arg of args) {
+    const [prefix, value] = arg.split('=', 2)
+    const data = value?.replace('"', '')
+
+    switch (prefix) {
+      case '-b', '--bitbucket':
+        bitbucket.workspace = data
+        break
+      case '-g', '--github':
+        github.organization = data
+        break
+      case '-c', '--csv':
+        versionsCsvUrl = data
+        break
+      default:
+        break
+    }
+  }
+
+  if (bitbucket.stores) {
+    assert(bbUsername, 'Please provide a BITBUCKET_USERNAME environment variable')
+    assert(bbAppPassword, 'Please provide a BITBUCKET_APP_PASSWORD environment variable')
+
+    bitbucket.username = bbUsername
+    bitbucket.appPassword = bbAppPassword
+  }
+
+  getSecurityVulnerabilitiesForMultiple({
+    bitbucket,
+    github,
+    versionsCsvUrl
+  }).then(writeToCsv).catch(exitWithError)
+
+} catch (e) {
+  exitWithError(e)
+}


### PR DESCRIPTION
###  Added

- Added scan.js, allowing user to pick github and/or bitbucket from cli, without needing a specific order

----

Note:

This is more of a stepping stone to other features that might be nice to have, including scanning local repos, local versions csv, scanning multiple repos/workspaces/orgs at once.  Albeit, none of those really require this to work. No need to approve this if not desired.