### PR TITLE
Gracefully handle repo scan failures

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,16 +135,16 @@ const getSecurityVulnerabilitiesForBitbucketRepo = async (
 
   try {
     const javaScriptDependencies = await bitbucket.getJavaScriptDependenciesOfRepo(
-        bitbucketUsername,
-        bitbucketAppPassword,
-        repo
+      bitbucketUsername,
+      bitbucketAppPassword,
+      repo
     )
     if (javaScriptDependencies === undefined) {
       console.log('(No JavaScript dependencies found)')
     } else {
       const javaScriptVulnerabilities = await getSecurityVulnerabilitiesForJavaScriptDependencies(
-          githubToken,
-          javaScriptDependencies
+        githubToken,
+        javaScriptDependencies
       )
       const javaScriptVulnerabilitiesWithRepo = javaScriptVulnerabilities.map(vulnerability => addRepoName(repo, vulnerability))
       allVulnerabilities = allVulnerabilities || []
@@ -152,16 +152,16 @@ const getSecurityVulnerabilitiesForBitbucketRepo = async (
     }
 
     const phpDependencies = await bitbucket.getPhpDependenciesOfRepo(
-        bitbucketUsername,
-        bitbucketAppPassword,
-        repo
+      bitbucketUsername,
+      bitbucketAppPassword,
+      repo
     )
     if (phpDependencies === undefined) {
       console.log('(No PHP dependencies found)')
     } else {
       const phpVulnerabilities = await getSecurityVulnerabilitiesForPhpDependencies(
-          githubToken,
-          phpDependencies
+        githubToken,
+        phpDependencies
       )
       const phpVulnerabilitiesWithRepo = phpVulnerabilities.map(vulnerability => addRepoName(repo, vulnerability))
       allVulnerabilities = allVulnerabilities || []
@@ -170,25 +170,25 @@ const getSecurityVulnerabilitiesForBitbucketRepo = async (
 
     if (versionsCsvUrl) {
       const nodeJsVersionVulnerabilities = await getNodeJsVersionVulnerabilitiesOfBitbucketRepo(
-          bitbucketUsername,
-          bitbucketAppPassword,
-          repo,
-          versionsCsvUrl
+        bitbucketUsername,
+        bitbucketAppPassword,
+        repo,
+        versionsCsvUrl
       )
       const nodeJsVersionVulnerabilitiesWithRepo = nodeJsVersionVulnerabilities.map(
-          vulnerability => addRepoName(repo, vulnerability)
+        vulnerability => addRepoName(repo, vulnerability)
       )
       allVulnerabilities = allVulnerabilities || []
       allVulnerabilities.push(...nodeJsVersionVulnerabilitiesWithRepo)
 
       const phpVersionVulnerabilities = await getPhpVersionVulnerabilitiesOfBitbucketRepo(
-          bitbucketUsername,
-          bitbucketAppPassword,
-          repo,
-          versionsCsvUrl
+        bitbucketUsername,
+        bitbucketAppPassword,
+        repo,
+        versionsCsvUrl
       )
       const phpVersionVulnerabilitiesWithRepo = phpVersionVulnerabilities.map(
-          vulnerability => addRepoName(repo, vulnerability)
+        vulnerability => addRepoName(repo, vulnerability)
       )
       allVulnerabilities = allVulnerabilities || []
       allVulnerabilities.push(...phpVersionVulnerabilitiesWithRepo)

--- a/index.js
+++ b/index.js
@@ -422,55 +422,72 @@ const getSecurityVulnerabilitiesForGitHubRepo = async (
 ) => {
   console.log(`Looking for vulnerabilities in GitHub ${repo}`)
   let allVulnerabilities
-  
-  const javaScriptDependencies = await github.getJavaScriptDependenciesOfRepo(githubToken, repo)
-  if (javaScriptDependencies === undefined) {
-    console.log('(No JavaScript dependencies found)')
-  } else {
-    const javaScriptVulnerabilities = await getSecurityVulnerabilitiesForJavaScriptDependencies(
-      githubToken,
-      javaScriptDependencies
-    )
-    const javaScriptVulnerabilitiesWithRepo = javaScriptVulnerabilities.map(vulnerability => addRepoName(repo, vulnerability))
-    allVulnerabilities = allVulnerabilities || []
-    allVulnerabilities.push(...javaScriptVulnerabilitiesWithRepo)
-  }
-  
-  const phpDependencies = await github.getPhpDependenciesOfRepo(githubToken, repo)
-  if (phpDependencies === undefined) {
-    console.log('(No PHP dependencies found)')
-  } else {
-    const phpVulnerabilities = await getSecurityVulnerabilitiesForPhpDependencies(
-      githubToken,
-      phpDependencies
-    )
-    const phpVulnerabilitiesWithRepo = phpVulnerabilities.map(vulnerability => addRepoName(repo, vulnerability))
-    allVulnerabilities = allVulnerabilities || []
-    allVulnerabilities.push(...phpVulnerabilitiesWithRepo)
-  }
-  
-  if (versionsCsvUrl) {
-    const nodeJsVersionVulnerabilities = await getNodeJsVersionVulnerabilitiesOfGitHubRepo(
-      githubToken,
+
+  try {
+    const javaScriptDependencies = await github.getJavaScriptDependenciesOfRepo(githubToken, repo)
+    if (javaScriptDependencies === undefined) {
+      console.log('(No JavaScript dependencies found)')
+    } else {
+      const javaScriptVulnerabilities = await getSecurityVulnerabilitiesForJavaScriptDependencies(
+        githubToken,
+        javaScriptDependencies
+      )
+      const javaScriptVulnerabilitiesWithRepo = javaScriptVulnerabilities.map(vulnerability => addRepoName(repo, vulnerability))
+      allVulnerabilities = allVulnerabilities || []
+      allVulnerabilities.push(...javaScriptVulnerabilitiesWithRepo)
+    }
+
+    const phpDependencies = await github.getPhpDependenciesOfRepo(githubToken, repo)
+    if (phpDependencies === undefined) {
+      console.log('(No PHP dependencies found)')
+    } else {
+      const phpVulnerabilities = await getSecurityVulnerabilitiesForPhpDependencies(
+        githubToken,
+        phpDependencies
+      )
+      const phpVulnerabilitiesWithRepo = phpVulnerabilities.map(vulnerability => addRepoName(repo, vulnerability))
+      allVulnerabilities = allVulnerabilities || []
+      allVulnerabilities.push(...phpVulnerabilitiesWithRepo)
+    }
+
+    if (versionsCsvUrl) {
+      const nodeJsVersionVulnerabilities = await getNodeJsVersionVulnerabilitiesOfGitHubRepo(
+        githubToken,
+        repo,
+        versionsCsvUrl
+      )
+      const nodeJsVersionVulnerabilitiesWithRepo = nodeJsVersionVulnerabilities.map(
+        vulnerability => addRepoName(repo, vulnerability)
+      )
+      allVulnerabilities = allVulnerabilities || []
+      allVulnerabilities.push(...nodeJsVersionVulnerabilitiesWithRepo)
+
+      const phpVersionVulnerabilities = await getPhpVersionVulnerabilitiesOfGitHubRepo(
+        githubToken,
+        repo,
+        versionsCsvUrl
+      )
+      const phpVersionVulnerabilitiesWithRepo = phpVersionVulnerabilities.map(
+        vulnerability => addRepoName(repo, vulnerability)
+      )
+      allVulnerabilities = allVulnerabilities || []
+      allVulnerabilities.push(...phpVersionVulnerabilitiesWithRepo)
+    }
+  } catch (error) {
+    const currentDate = getHyphenatedDate()
+    const failureToCheck = {
+      detailsUrl: null,
+      ecosystem: null,
+      identifiers: [],
+      inspectedOn: currentDate,
+      packageName: null,
       repo,
-      versionsCsvUrl
-    )
-    const nodeJsVersionVulnerabilitiesWithRepo = nodeJsVersionVulnerabilities.map(
-      vulnerability => addRepoName(repo, vulnerability)
-    )
+      severity: 'HIGH',
+      summary: `Failed to scan GitHub repo: ${error}`,
+      vulnerableVersionRange: null
+    }
     allVulnerabilities = allVulnerabilities || []
-    allVulnerabilities.push(...nodeJsVersionVulnerabilitiesWithRepo)
-    
-    const phpVersionVulnerabilities = await getPhpVersionVulnerabilitiesOfGitHubRepo(
-      githubToken,
-      repo,
-      versionsCsvUrl
-    )
-    const phpVersionVulnerabilitiesWithRepo = phpVersionVulnerabilities.map(
-      vulnerability => addRepoName(repo, vulnerability)
-    )
-    allVulnerabilities = allVulnerabilities || []
-    allVulnerabilities.push(...phpVersionVulnerabilitiesWithRepo)
+    allVulnerabilities.push(failureToCheck)
   }
   
   return allVulnerabilities

--- a/index.js
+++ b/index.js
@@ -132,65 +132,82 @@ const getSecurityVulnerabilitiesForBitbucketRepo = async (
 ) => {
   console.log(`Looking for vulnerabilities in Bitbucket ${repo}`)
   let allVulnerabilities
-  
-  const javaScriptDependencies = await bitbucket.getJavaScriptDependenciesOfRepo(
-    bitbucketUsername,
-    bitbucketAppPassword,
-    repo
-  )
-  if (javaScriptDependencies === undefined) {
-    console.log('(No JavaScript dependencies found)')
-  } else {
-    const javaScriptVulnerabilities = await getSecurityVulnerabilitiesForJavaScriptDependencies(
-      githubToken,
-      javaScriptDependencies
+
+  try {
+    const javaScriptDependencies = await bitbucket.getJavaScriptDependenciesOfRepo(
+        bitbucketUsername,
+        bitbucketAppPassword,
+        repo
     )
-    const javaScriptVulnerabilitiesWithRepo = javaScriptVulnerabilities.map(vulnerability => addRepoName(repo, vulnerability))
-    allVulnerabilities = allVulnerabilities || []
-    allVulnerabilities.push(...javaScriptVulnerabilitiesWithRepo)
-  }
-  
-  const phpDependencies = await bitbucket.getPhpDependenciesOfRepo(
-    bitbucketUsername,
-    bitbucketAppPassword,
-    repo
-  )
-  if (phpDependencies === undefined) {
-    console.log('(No PHP dependencies found)')
-  } else {
-    const phpVulnerabilities = await getSecurityVulnerabilitiesForPhpDependencies(
-      githubToken,
-      phpDependencies
+    if (javaScriptDependencies === undefined) {
+      console.log('(No JavaScript dependencies found)')
+    } else {
+      const javaScriptVulnerabilities = await getSecurityVulnerabilitiesForJavaScriptDependencies(
+          githubToken,
+          javaScriptDependencies
+      )
+      const javaScriptVulnerabilitiesWithRepo = javaScriptVulnerabilities.map(vulnerability => addRepoName(repo, vulnerability))
+      allVulnerabilities = allVulnerabilities || []
+      allVulnerabilities.push(...javaScriptVulnerabilitiesWithRepo)
+    }
+
+    const phpDependencies = await bitbucket.getPhpDependenciesOfRepo(
+        bitbucketUsername,
+        bitbucketAppPassword,
+        repo
     )
-    const phpVulnerabilitiesWithRepo = phpVulnerabilities.map(vulnerability => addRepoName(repo, vulnerability))
-    allVulnerabilities = allVulnerabilities || []
-    allVulnerabilities.push(...phpVulnerabilitiesWithRepo)
-  }
-  
-  if (versionsCsvUrl) {
-    const nodeJsVersionVulnerabilities = await getNodeJsVersionVulnerabilitiesOfBitbucketRepo(
-      bitbucketUsername,
-      bitbucketAppPassword,
+    if (phpDependencies === undefined) {
+      console.log('(No PHP dependencies found)')
+    } else {
+      const phpVulnerabilities = await getSecurityVulnerabilitiesForPhpDependencies(
+          githubToken,
+          phpDependencies
+      )
+      const phpVulnerabilitiesWithRepo = phpVulnerabilities.map(vulnerability => addRepoName(repo, vulnerability))
+      allVulnerabilities = allVulnerabilities || []
+      allVulnerabilities.push(...phpVulnerabilitiesWithRepo)
+    }
+
+    if (versionsCsvUrl) {
+      const nodeJsVersionVulnerabilities = await getNodeJsVersionVulnerabilitiesOfBitbucketRepo(
+          bitbucketUsername,
+          bitbucketAppPassword,
+          repo,
+          versionsCsvUrl
+      )
+      const nodeJsVersionVulnerabilitiesWithRepo = nodeJsVersionVulnerabilities.map(
+          vulnerability => addRepoName(repo, vulnerability)
+      )
+      allVulnerabilities = allVulnerabilities || []
+      allVulnerabilities.push(...nodeJsVersionVulnerabilitiesWithRepo)
+
+      const phpVersionVulnerabilities = await getPhpVersionVulnerabilitiesOfBitbucketRepo(
+          bitbucketUsername,
+          bitbucketAppPassword,
+          repo,
+          versionsCsvUrl
+      )
+      const phpVersionVulnerabilitiesWithRepo = phpVersionVulnerabilities.map(
+          vulnerability => addRepoName(repo, vulnerability)
+      )
+      allVulnerabilities = allVulnerabilities || []
+      allVulnerabilities.push(...phpVersionVulnerabilitiesWithRepo)
+    }
+  } catch (error) {
+    const currentDate = getHyphenatedDate()
+    const failureToCheck = {
+      detailsUrl: null,
+      ecosystem: null,
+      identifiers: [],
+      inspectedOn: currentDate,
+      packageName: null,
       repo,
-      versionsCsvUrl
-    )
-    const nodeJsVersionVulnerabilitiesWithRepo = nodeJsVersionVulnerabilities.map(
-      vulnerability => addRepoName(repo, vulnerability)
-    )
+      severity: 'HIGH',
+      summary: `Failed to scan Bitbucket repo: ${error}`,
+      vulnerableVersionRange: null
+    }
     allVulnerabilities = allVulnerabilities || []
-    allVulnerabilities.push(...nodeJsVersionVulnerabilitiesWithRepo)
-    
-    const phpVersionVulnerabilities = await getPhpVersionVulnerabilitiesOfBitbucketRepo(
-      bitbucketUsername,
-      bitbucketAppPassword,
-      repo,
-      versionsCsvUrl
-    )
-    const phpVersionVulnerabilitiesWithRepo = phpVersionVulnerabilities.map(
-      vulnerability => addRepoName(repo, vulnerability)
-    )
-    allVulnerabilities = allVulnerabilities || []
-    allVulnerabilities.push(...phpVersionVulnerabilitiesWithRepo)
+    allVulnerabilities.push(failureToCheck)
   }
   
   return allVulnerabilities


### PR DESCRIPTION
### Changed
- If we fail to check a Bitbucket repo, report that and keep going
- If we fail to check a GitHub repo, report that and keep going

---

Previously, it would simply die with an error message (to avoid giving incorrect data about what vulnerabilities exist, since we were not able to scan a particular repo). Instead, this reports that as a HIGH severity issue and lets the scan continue so that we can still access the other repos' results, while still knowing about this problem.